### PR TITLE
Install timber (HTTP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'devise'
 
 gem 'omniauth'
 
+gem 'timber', github: 'timberio/timber-ruby'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/timberio/timber-ruby.git
+  revision: f38c82039bec204860aa942be07077db7e71c07e
+  specs:
+    timber (2.1.0)
+      msgpack (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,6 +91,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     nio4r (2.0.0)
     nokogiri (1.7.0.1)
@@ -183,10 +191,11 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  timber!
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.14.3
+   1.15.0

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,15 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Install the Timber.io logger, send logs over HTTP.
+  # Note: When you are done testing, simply instantiate the logger like this:
+#
+#   logger = Timber::Logger.new(STDOUT)
+#
+# Be sure to remove the "log_device =" and "logger =" lines below.
+  logger = Timber::Logger.new(STDOUT)
+  logger.level = config.log_level
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,11 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Install the Timber.io logger, send logs over HTTP.
+  log_device = Timber::LogDevices::HTTP.new(ENV['TIMBER_API_KEY'])
+  logger = Timber::Logger.new(log_device)
+  logger.level = config.log_level
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,11 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Install the Timber.io logger but silence all logs (log to nil). We install the
+  # logger to ensure the Rails.logger object exposes the proper API.
+  logger = Timber::Logger.new(nil)
+  logger.level = config.log_level
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
 end

--- a/config/initializers/timber.rb
+++ b/config/initializers/timber.rb
@@ -1,0 +1,18 @@
+# Timber.io Ruby Configuration - Simple Structured Logging
+#
+#  ^  ^  ^   ^      ___I_      ^  ^   ^  ^  ^   ^  ^
+# /|\/|\/|\ /|\    /\-_--\    /|\/|\ /|\/|\/|\ /|\/|\
+# /|\/|\/|\ /|\   /  \_-__\   /|\/|\ /|\/|\/|\ /|\/|\
+# /|\/|\/|\ /|\   |[]| [] |   /|\/|\ /|\/|\/|\ /|\/|\
+# -------------------------------------------------------------------
+# Website:       https://timber.io
+# Documentation: https://timber.io/docs
+# Support:       support@timber.io
+# -------------------------------------------------------------------
+
+config = Timber::Config.instance
+
+# Add additional configuration here.
+# For a full list of configuration options and their explanations see:
+# http://www.rubydoc.info/github/timberio/timber-ruby/Timber/Config
+


### PR DESCRIPTION
Demonstrates installing Timber to send logs via HTTP.

Note, this installation was completed with a simple install command:

```
bundle exec timber install <api-key>
```